### PR TITLE
redirect after register

### DIFF
--- a/auth/.idea/.gitignore
+++ b/auth/.idea/.gitignore
@@ -3,3 +3,5 @@
 /workspace.xml
 # Editor-based HTTP Client requests
 /httpRequests/
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/auth/auth/settings.py
+++ b/auth/auth/settings.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 from login.startup import keygen
 
+from ourJWT import OUR_class
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/auth/auth/settings.py
+++ b/auth/auth/settings.py
@@ -12,8 +12,6 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import os
 from pathlib import Path
 
-from login.startup import keygen
-
 from ourJWT import OUR_class, OUR_exception
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -139,31 +137,9 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-PRIVATE_KEY = keygen()
 
 if os.getenv("USER") == "gd-harco":
     print("Using debug local datase")
     DATABASES['default'] = DATABASES["debug"]
 else:
     print(f'Using default distant database')
-
-PUBKEY = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+UsBSBGi71VYLGUL5nCz
-o7NK/VveP2OCqt1SsYrls2OmzyQMs5sjNeVAY3XMf15h5OD5ylCYD8eTILy4PXyD
-OShIJyAM6+sfMJh9StKkvkUVRcq+6weg8ueb4obZYddC2YkYAbncjeF2nGQEbG2y
-ecZhAXgaPfUZSQqjvCu/haSMo8C5S8+H66jwBV8pv4ewhtdlOV4NM1go7E0BWtgK
-6iN8x1PChBsninsfEnyxXME/Ubush7sZ+IKyScXc+87niaR/omlHeL6m/MzsS/qL
-tUQzm0UwPhHOBcILO9eGW/DY0W1Hs/8fqSQ5gvcksmS6rShqBb2IxOq2S0eDgCPM
-+QIDAQAB
------END PUBLIC KEY-----"""
-
-
-encoder: OUR_class.Encoder
-decoder: OUR_class.Decoder
-
-try:
-    encoder = OUR_class.Encoder(PRIVATE_KEY)
-    decoder = OUR_class.Decoder(PUBKEY)
-except OUR_exception.NoKey:
-    print("NO KEY ERROR")
-    exit

--- a/auth/auth/settings.py
+++ b/auth/auth/settings.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from login.startup import keygen
 
-from ourJWT import OUR_class
+from ourJWT import OUR_class, OUR_exception
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -30,7 +30,8 @@ SECRET_KEY = 'django-insecure-bha_z48$lrtojju%5*y5y399k@f%c5!dnu80pbm7u)ccg$l_4y
 DEBUG = True
 
 ALLOWED_HOSTS = [
-    '82.64.223.220'
+    '82.64.223.220',
+    '127.0.0.1'
 ]
 
 
@@ -145,3 +146,24 @@ if os.getenv("USER") == "gd-harco":
     DATABASES['default'] = DATABASES["debug"]
 else:
     print(f'Using default distant database')
+
+PUBKEY = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+UsBSBGi71VYLGUL5nCz
+o7NK/VveP2OCqt1SsYrls2OmzyQMs5sjNeVAY3XMf15h5OD5ylCYD8eTILy4PXyD
+OShIJyAM6+sfMJh9StKkvkUVRcq+6weg8ueb4obZYddC2YkYAbncjeF2nGQEbG2y
+ecZhAXgaPfUZSQqjvCu/haSMo8C5S8+H66jwBV8pv4ewhtdlOV4NM1go7E0BWtgK
+6iN8x1PChBsninsfEnyxXME/Ubush7sZ+IKyScXc+87niaR/omlHeL6m/MzsS/qL
+tUQzm0UwPhHOBcILO9eGW/DY0W1Hs/8fqSQ5gvcksmS6rShqBb2IxOq2S0eDgCPM
++QIDAQAB
+-----END PUBLIC KEY-----"""
+
+
+encoder: OUR_class.Encoder
+decoder: OUR_class.Decoder
+
+try:
+    encoder = OUR_class.Encoder(PRIVATE_KEY)
+    decoder = OUR_class.Decoder(PUBKEY)
+except OUR_exception.NoKey:
+    print("NO KEY ERROR")
+    exit

--- a/auth/auth/urls.py
+++ b/auth/auth/urls.py
@@ -22,4 +22,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('login/', endpoint.login_endpoint),
     path('register/', endpoint.register_endpoint),
+    path('refresh/', endpoint.refresh_auth_token),
+    path('test/', endpoint.test_decorator)
 ]

--- a/auth/login/__init__.py
+++ b/auth/login/__init__.py
@@ -1,0 +1,1 @@
+from .crypto import encoder, decoder

--- a/auth/login/__init__.py
+++ b/auth/login/__init__.py
@@ -1,1 +1,1 @@
-from .crypto import encoder, decoder
+from .crypto import encoder

--- a/auth/login/crypto.py
+++ b/auth/login/crypto.py
@@ -1,13 +1,14 @@
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 
-from django.conf import settings
+from ourJWT import OUR_class, OUR_exception
 
 def keygen():
     private_key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048
     )
+    print (f"Generated private key : {private_key}")
     public_key = private_key.public_key
     private_key_bytes = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -17,9 +18,26 @@ def keygen():
 
     public_key = private_key.public_key()
     pem = public_key.public_bytes(
-         encoding=serialization.Encoding.PEM,
-       format=serialization.PublicFormat.SubjectPublicKeyInfo
-       )
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
     with open('public_key.pem', 'wb') as f:
         f.write(pem)
     return private_key_bytes.decode()
+
+PRIVKEY = keygen()
+
+with open('public_key.pem', 'rb') as f:
+    PUBKEY = f.read()
+
+
+encoder: OUR_class.Encoder
+decoder: OUR_class.Decoder
+
+try:
+    encoder = OUR_class.Encoder(PRIVKEY)
+    decoder = OUR_class.Decoder(PUBKEY)
+    print(f"created both encoder and decoder object")
+except OUR_exception.NoKey:
+    print("NO KEY ERROR")
+    exit

--- a/auth/login/crypto.py
+++ b/auth/login/crypto.py
@@ -3,12 +3,13 @@ from cryptography.hazmat.primitives import serialization
 
 from ourJWT import OUR_class, OUR_exception
 
+
 def keygen():
     private_key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048
     )
-    print (f"Generated private key : {private_key}")
+    print(f"Generated private key : {private_key}")
     public_key = private_key.public_key
     private_key_bytes = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -30,13 +31,11 @@ PRIVKEY = keygen()
 with open('public_key.pem', 'rb') as f:
     PUBKEY = f.read()
 
-
 encoder: OUR_class.Encoder
-decoder: OUR_class.Decoder
+OUR_class.Decoder.pub_key = PUBKEY
 
 try:
     encoder = OUR_class.Encoder(PRIVKEY)
-    decoder = OUR_class.Decoder(PUBKEY)
     print(f"created both encoder and decoder object")
 except OUR_exception.NoKey:
     print("NO KEY ERROR")

--- a/auth/login/endpoint.py
+++ b/auth/login/endpoint.py
@@ -56,16 +56,14 @@ def login_endpoint(request: HttpRequest):
         return response.HttpResponse(status=401, reason='Invalid credential')
 
     if user.password == password:
-        full_response = response.HttpResponse()
-        full_response.set_cookie(key='refresh_token', value=user.generate_refresh_token(), secure=True, httponly=True)
-        return return_user_cookie(user, full_response)
+        return return_refresh_token(user=user)
     else:
         return response.HttpResponse(status=401, reason='Invalid credential')
 
 
 @csrf_exempt  # TODO: DO NOT USE IN PRODUCTION
 @require_POST
-def register_endpoint(request):
+def register_endpoint(request: HttpRequest):
     try:
         data = json.loads(request.body)
     except json.JSONDecodeError:
@@ -85,10 +83,8 @@ def register_endpoint(request):
     new_user = User(login=login, password=password, displayName=display_name)
     new_user.save()
 
-    return response.JsonResponse({'refresh_token': new_user.generate_refresh_token()}, status=200)
+    return return_refresh_token(new_user)
 
-
-#TODO: Check if auth token is in request, refuse if not the case
 @csrf_exempt  # TODO: DO NOT USE IN PRODUCTION
 @require_GET
 def refresh_auth_token(request: HttpRequest, *args):

--- a/auth/login/endpoint.py
+++ b/auth/login/endpoint.py
@@ -20,7 +20,7 @@ from ourJWT import decorators
 duration = int(os.getenv("AUTH_LIFETIME", "10"))
 
 
-def return_user_cookie(user: User, full_response: response.HttpResponse):
+def return_auth_cookie(user: User, full_response: response.HttpResponse):
     user_dict = model_to_dict(user)
     expdate = datetime.now() + timedelta(seconds=5)
     user_dict["exp"] = expdate
@@ -28,6 +28,10 @@ def return_user_cookie(user: User, full_response: response.HttpResponse):
     full_response.set_cookie(key="auth_token", value=payload, secure=True, httponly=True)
     return full_response
 
+def return_refresh_token(user: User):
+    full_response = response.HttpResponse()
+    full_response.set_cookie(key='refresh_token', value=user.generate_refresh_token(), secure=True, httponly=True)
+    return return_auth_cookie(user, full_response)
 
 # Create your views here.
 
@@ -117,7 +121,7 @@ def refresh_auth_token(request: HttpRequest, *args):
     if id != user.jwt_emitted:
         return response.HttpResponseBadRequest(reason="token error")
 
-    return return_user_cookie(user, response.HttpResponse(status=200))
+    return return_auth_cookie(user, response.HttpResponse(status=200))
 
 
 @ourJWT.Decoder.check_auth()

--- a/auth/login/endpoint.py
+++ b/auth/login/endpoint.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timedelta
 
+import ourJWT.OUR_exception
 from django.http import response, HttpRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_GET, require_http_methods
 from django.forms.models import model_to_dict
+from django.shortcuts import get_object_or_404
 
 from . import crypto
 from django.core import exceptions
@@ -20,26 +22,25 @@ duration = int(os.getenv("AUTH_LIFETIME", "10"))
 
 def return_user_cookie(user: User, full_response: response.HttpResponse):
     user_dict = model_to_dict(user)
-    expdate = datetime.now() + timedelta(minutes=duration)
+    expdate = datetime.now() + timedelta(seconds=5)
     user_dict["exp"] = expdate
     payload = crypto.encoder.encode(user_dict, "auth")
-    full_response.set_cookie("auth_token", payload, max_age=None, secure=True, Http_only=True)
+    full_response.set_cookie(key="auth_token", value=payload, secure=True, httponly=True)
     return full_response
 
 
 # Create your views here.
-
 
 #TODO: ne pas envoyer le refresh token en body, mais en cookie http only : https://dev.to/bcerati/les-cookies-httponly-une-securite-pour-vos-tokens-2p8n
 #TODO: get info in Authorization request header https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
 @csrf_exempt  # TODO: DO NOT USE IN PRODUCTION
 @require_GET
 def login_endpoint(request: HttpRequest):
-    auth: str = request.headers["Authorization:"]
+    auth: str = request.headers.get("Authorization", None)
     if auth is None:
         return response.HttpResponseBadRequest(reason="No Authorization header found in request")
     auth_type: str = auth.split(" ")[0]
-    if (auth_type) != "Basic":
+    if auth_type != "Basic":
         return response.HttpResponseBadRequest(reason="invalid Authorization type")
     auth_data: str = auth.split(" ")[1]
     login = auth_data.split("/")[0]
@@ -51,11 +52,12 @@ def login_endpoint(request: HttpRequest):
         return response.HttpResponse(status=401, reason='Invalid credential')
 
     if user.password == password:
-        full_response =  response.HttpResponse()
-        full_response.set_cookie('refresh_token', user.generate_refresh_token(), secure=True, httponly=True)
+        full_response = response.HttpResponse()
+        full_response.set_cookie(key='refresh_token', value=user.generate_refresh_token(), secure=True, httponly=True)
         return return_user_cookie(user, full_response)
     else:
         return response.HttpResponse(status=401, reason='Invalid credential')
+
 
 @csrf_exempt  # TODO: DO NOT USE IN PRODUCTION
 @require_POST
@@ -83,30 +85,43 @@ def register_endpoint(request):
 
 
 #TODO: Check if auth token is in request, refuse if not the case
-@decorators.auth_required(crypto.decoder)
 @csrf_exempt  # TODO: DO NOT USE IN PRODUCTION
 @require_GET
 def refresh_auth_token(request: HttpRequest, *args):
-    #
     try:
-        data = json.loads(request.body)
-    except json.JSONDecodeError:
-        return response.HttpResponseBadRequest(reason="JSON Decode Error")
-
-    expected_key = {"refresh_token"}
-    if set(data.keys()) != expected_key:
-        return response.HttpResponseBadRequest(reason="Bad keys")
-
-    token = data["refresh_token"]
+        request.COOKIES["auth_token"]
+    except:
+        return response.HttpResponseBadRequest(reason="no auth token")
+    try:
+        auth = ourJWT.Decoder.decode(request.COOKIES.get("auth_token"), check_date=False)
+    except:
+        return response.HttpResponseBadRequest(reason='bad auth token')
+    auth_login = auth.get("login")
 
     try:
-        payload = crypto.decoder.decode(token)
-        # payload = jwt.decode(jwt=token, key=settings.PRIVATE_KEY, algorithms=["RS256"])
-        user = User.objects.get(login=payload["user_id"])
-        id = payload["id"]
-    # except (jwt.DecodeError, jwt.ExpiredSignatureError, exceptions.ObjectDoesNotExist, KeyError):
-    #     return response.HttpResponseBadRequest(reason="Invalid refresh Token")
+        request.COOKIES["refresh_token"]
+    except:
+        return response.HttpResponseBadRequest(reason="no refresh token")
+    try:
+        refresh = ourJWT.Decoder.decode(request.COOKIES.get("refresh_token"))
+    except:
+        return response.HttpResponseBadRequest("decode error")
+
+    refresh_pk = refresh.get("pk")
+    user = get_object_or_404(User, pk=refresh_pk)
+
+    if user.login != auth_login:
+        return response.HttpResponseForbidden("token error")
+
+    id = refresh["jti"]
     if id != user.jwt_emitted:
-        return response.HttpResponseBadRequest(reason="Invalid refresh Token")
+        return response.HttpResponseBadRequest(reason="token error")
 
     return return_user_cookie(user, response.HttpResponse(status=200))
+
+
+@ourJWT.Decoder.check_auth()
+def test_decorator(request, **kwargs):
+    auth = kwargs["token"]
+    print(auth)
+    return response.HttpResponse()

--- a/auth/login/models.py
+++ b/auth/login/models.py
@@ -4,8 +4,7 @@ from django.db import models
 from django.core.validators import MinLengthValidator
 from django.conf import settings
 
-import jwt
-
+from crypto import encoder
 
 # Create your models here.
 class User(models.Model):
@@ -26,12 +25,10 @@ class User(models.Model):
     jwt_emitted = models.IntegerField(default=0)
 
     def generate_refresh_token(self):
-        priv = settings.PRIVATE_KEY
         expdate = datetime.now() + timedelta(days=7)
         payload = {
             "sub": self.login,
             "id": self.jwt_emitted,
             "exp": expdate
         }
-        return settings
-        # return jwt.encode(payload, priv, "RS256")
+        return encoder.encode(payload, "refresh")

--- a/auth/login/models.py
+++ b/auth/login/models.py
@@ -33,4 +33,5 @@ class User(models.Model):
             "id": self.jwt_emitted,
             "exp": expdate
         }
-        return jwt.encode(payload, priv, "RS256")
+        return settings
+        # return jwt.encode(payload, priv, "RS256")

--- a/auth/login/models.py
+++ b/auth/login/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.core.validators import MinLengthValidator
 from django.conf import settings
 
-from crypto import encoder
+from .crypto import encoder
 
 # Create your models here.
 class User(models.Model):
@@ -27,8 +27,8 @@ class User(models.Model):
     def generate_refresh_token(self):
         expdate = datetime.now() + timedelta(days=7)
         payload = {
-            "sub": self.login,
-            "id": self.jwt_emitted,
+            "pk": self.pk,
+            "jti": self.jwt_emitted,
             "exp": expdate
         }
         return encoder.encode(payload, "refresh")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cffi==1.16.0
 cryptography==42.0.5
 Django==5.0.4
 gunicorn==21.2.0
-ourJWT==0.0.2
+ourJWT==0.1.1
 packaging==24.0
 psycopg==3.1.18
 pycparser==2.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ cffi==1.16.0
 cryptography==42.0.5
 Django==5.0.4
 gunicorn==21.2.0
+ourJWT==0.0.2
 packaging==24.0
 psycopg==3.1.18
-pycparser==2.21
+pycparser==2.22
 PyJWT==2.8.0
 sqlparse==0.4.4
-typing_extensions==4.10.0
+typing_extensions==4.11.0


### PR DESCRIPTION
- **to much change, must properly review**
- **small progress, must transfer all to ourJWT**
- **moved all crypto related logic from settings.py and startup.py to a new file crypto.py Imported decoder and encoder in init.py for auth app**
- **LOGIN_ENDPOINT: updated parsing logic,  mow get credential from request's header "Authorization"**
- **LOGIN_ENDPOINT: updated refresh_token storage, now in http only cookie USER_MODEL: Updated refrewsh token generation using ourJWT package**
- **Implemented ourJWT package to handle all things related to JWT. Added refresh endpoint and a endpoin to test the decorator**
- **renamed "return_user_cookie" to "return_auth_cookie", created "return_refresh_token" that created the refresh token, than call "return_auth_cookie"**
- **register and login now b oth called "retur_refresh_token", allowing for an auto-login after regristration**
